### PR TITLE
Fixed i_error saturation when i_gain is negative

### DIFF
--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -363,7 +363,7 @@ double Pid::computeCommand(double error, double error_dot, ros::Duration dt)
   if(antiwindup_)
   {
     // Prevent i_error_ from climbing higher than permitted by i_max_/i_min_
-    i_error_ = std::max(gains.i_min_ / gains.i_gain_, std::min(i_error_, gains.i_max_ / gains.i_gain_));
+    i_error_ = std::max(gains.i_min_ / std::fabs(gains.i_gain_), std::min(i_error_, gains.i_max_ / std::fabs(gains.i_gain_)));
   }
 
   // Calculate integral contribution to command


### PR DESCRIPTION
There is a computation error in the saturation of the  `i_error` term in the case `i_gain`  is negative, the `i_error` term is saturated all the time at the max limit.

detailed proof
suppose `p_gain = i_gain = -1.0, d_gain = 0.0, i_max = 0.5, i_min = -0.5, dt = 1.0s`
if `p_error = 1.0`
`p_term = -1.0`
`i_error = 1.0`
without antiwindup, `i_term  = -1.0`
it is saturated with  `i_term = max( -0.5 , min( -1.0 , 0.5)) = -0.5` which contributes to the command in the same direction as `p_term`
with antiwindup, i_error is saturated with 
`i_error = max( -0.5 / -1.0, min( 1.0 , 0.5 / -1.0)) = 0.5` which is in the opposite direction of `p_term`.
this is even worse as the `i_error` is always 0.5 what ever previous `i_error`.
The same for `p_error = -1.0`

Using a absolute value on the gain solves the issue. 
Tested on positive and negative gains settings in PID in real hardware (Shadow hands with mixed_position_velocity_controller)
